### PR TITLE
tolerate numba 0.49 targets -> core change

### DIFF
--- a/pycox/evaluation/admin.py
+++ b/pycox/evaluation/admin.py
@@ -5,7 +5,7 @@ from pycox.utils import idx_at_times
 
 
 def administrative_scores(func):
-    if type(func) is not numba.targets.registry.CPUDispatcher:
+    if not func.__class__.__module__.startswith('numba'):
         raise ValueError("Need to provide numba compiled function")
     def metric(time_grid, durations, durations_c, events, surv, index_surv, reduce=True, steps_surv='post'):
         if not hasattr(time_grid, '__iter__'):

--- a/pycox/evaluation/ipcw.py
+++ b/pycox/evaluation/ipcw.py
@@ -32,8 +32,8 @@ def _inv_cens_scores(func, time_grid, durations, events, surv, censor_surv, idx_
                                idx_ts_censor_i, idx_tt_censor, scores_i, weights_i, n_indiv, max_weight)
 
 def _inverse_censoring_weighted_metric(func):
-    if type(func) is not numba.targets.registry.CPUDispatcher:
-        raise ValueError("Need to provide nuba combiled function")
+    if not func.__class__.__module__.startswith('numba'):
+        raise ValueError("Need to provide numba compiled function")
     def metric(time_grid, durations, events, surv, censor_surv, index_surv, index_censor, max_weight=np.inf,
                reduce=True, steps_surv='post', steps_censor='post'):
         if not hasattr(time_grid, '__iter__'):


### PR DESCRIPTION
numba 0.49 moved the 'registry.CPUDispatcher' class from
'numba.targets' to 'numba.core'. Update a couple uses of
'numba.targets' to tolerate either the old or new layout.