### PR TITLE
allow override of dataset storage directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ from pycox import datasets
 df = datasets.metabric.read_df()
 ```
 
+The `datasets` module will store datasets under the installation directory by default. You can specify a different directory by setting the `PYCOX_DATA_DIR` environment variable.
+
 ## Real Datasets:
 <table>
     <tr>

--- a/pycox/datasets/_dataset_loader.py
+++ b/pycox/datasets/_dataset_loader.py
@@ -1,10 +1,15 @@
 from pathlib import Path
 import pandas as pd
 import pycox
+import os
 
-_PATH_ROOT = Path(pycox.__file__).parent
+_DATA_OVERRIDE = os.environ.get('PYCOX_DATA_DIR', None)
+if _DATA_OVERRIDE:
+    _PATH_ROOT = Path(_DATA_OVERRIDE)
+else:
+    _PATH_ROOT = Path(pycox.__file__).parent
 _PATH_DATA = _PATH_ROOT / 'datasets' / 'data'
-_PATH_DATA.mkdir(exist_ok=True)
+_PATH_DATA.mkdir(parents=True, exist_ok=True)
 
 class _DatasetLoader:
     """Abstract class for loading data sets.

--- a/pycox/datasets/_dataset_loader.py
+++ b/pycox/datasets/_dataset_loader.py
@@ -5,10 +5,10 @@ import os
 
 _DATA_OVERRIDE = os.environ.get('PYCOX_DATA_DIR', None)
 if _DATA_OVERRIDE:
-    _PATH_ROOT = Path(_DATA_OVERRIDE)
+    _PATH_DATA = Path(_DATA_OVERRIDE)
 else:
     _PATH_ROOT = Path(pycox.__file__).parent
-_PATH_DATA = _PATH_ROOT / 'datasets' / 'data'
+    _PATH_DATA = _PATH_ROOT / 'datasets' / 'data'
 _PATH_DATA.mkdir(parents=True, exist_ok=True)
 
 class _DatasetLoader:


### PR DESCRIPTION
The `pycox.datasets` module stores datasets under the installation
directory by default. Add an environment variable to allow a user
to specify a different directory for data storage.

This would be useful to allow sharing a data store among a user's
various python venvs, for example. Or to allow a single pycox
installation to be shared among multiple users, each with their
own private data store.