### PR TITLE
fix: fixing the part3 of the nll loss parametrized with PMF

### DIFF
--- a/pycox/models/loss.py
+++ b/pycox/models/loss.py
@@ -86,7 +86,7 @@ def nll_pmf(phi: Tensor, idx_durations: Tensor, events: Tensor, reduction: str =
     sum_ = cumsum[:, -1]
     part1 = phi.gather(1, idx_durations).view(-1).sub(gamma).mul(events)
     part2 = - sum_.relu().add(epsilon).log()
-    part3 = sum_.sub(cumsum.gather(1, idx_durations).view(-1)).relu().add(epsilon).log().mul(1. - events)
+    part3 = sum_.sub(cumsum.gather(1, idx_durations+1).view(-1)).relu().add(epsilon).log().mul(1. - events)
     # need relu() in part3 (and possibly part2) because cumsum on gpu has some bugs and we risk getting negative numbers.
     loss = - part1.add(part2).add(part3)
     return _reduction(loss, reduction)


### PR DESCRIPTION
First, thanks for your work and the repository. While doing some research with the DeepHitSingle model, we (@EileenHsieh) encountered an issue that might be a bug. Particularly, this potential bug concerns the loss function -- nll_pmf. We first noticed this when predicting survival curves. All of them had a sudden drop in the last bin (see example 1), which is not the bin introduced by pad_col because it is removed in the predict function. 

Example 1: 
![image](https://user-images.githubusercontent.com/9193243/188792347-59e8fd35-7a55-4c64-8c97-ea71c0712913.png)

After checking the code and the loss function described in the paper (https://doi.org/10.1007/s10985-021-09532-6), we saw that part3 of the loss is lacking +1 in the idx_durations. That is, a censored sample i with duration k(t_i) (idx_duration) had survived until that time and the loss should consider the probability of survival after such time bin: cumulative sum from k(ti)+1 to m+1. This change agrees with expression 11 of the paper and it would fix the sudden drop mentioned before as shown in example 2.

Example 2: 
![image](https://user-images.githubusercontent.com/9193243/188792384-d2d2ffad-b0ec-49a0-8a5a-90975af1ccab.png)



