### PR TITLE
Use is_monotonic_increasing to allow Pandas 2.0

### DIFF
--- a/pycox/evaluation/eval_surv.py
+++ b/pycox/evaluation/eval_surv.py
@@ -33,7 +33,7 @@ class EvalSurv:
         self.censor_surv = censor_surv
         self.censor_durations = censor_durations
         self.steps = steps
-        assert pd.Series(self.index_surv).is_monotonic
+        assert pd.Series(self.index_surv).is_monotonic_increasing
 
     @property
     def censor_surv(self):


### PR DESCRIPTION
Use is_monotonic_increasing (instead of is_monotonic) for Pandas 2.0 compatibility, without breaking backward compatibility with 1.5.