### PR TITLE
Convert docstrings with latex-like maths into raw strings

### DIFF
--- a/pycox/__init__.py
+++ b/pycox/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Haavard Kvamme"""
 __email__ = 'haavard.kvamme@gmail.com'
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 import pycox.datasets
 import pycox.evaluation

--- a/pycox/models/loss.py
+++ b/pycox/models/loss.py
@@ -405,7 +405,7 @@ def cox_cc_loss_single_ctrl(g_case: Tensor, g_control: Tensor, shrink: float = 0
     return loss
 
 def cox_ph_loss_sorted(log_h: Tensor, events: Tensor, eps: float = 1e-7) -> Tensor:
-    """Requires the input to be sorted by descending duration time.
+    r"""Requires the input to be sorted by descending duration time.
     See DatasetDurationSorted.
 
     We calculate the negative log of $(\frac{h_i}{\sum_{j \in R_i} h_j})^d$,
@@ -423,7 +423,7 @@ def cox_ph_loss_sorted(log_h: Tensor, events: Tensor, eps: float = 1e-7) -> Tens
     return - log_h.sub(log_cumsum_h).mul(events).sum().div(events.sum())
 
 def cox_ph_loss(log_h: Tensor, durations: Tensor, events: Tensor, eps: float = 1e-7) -> Tensor:
-    """Loss for CoxPH model. If data is sorted by descending duration, see `cox_ph_loss_sorted`.
+    r"""Loss for CoxPH model. If data is sorted by descending duration, see `cox_ph_loss_sorted`.
 
     We calculate the negative log of $(\frac{h_i}{\sum_{j \in R_i} h_j})^d$,
     where h = exp(log_h) are the hazards and R is the risk set, and d is event.
@@ -668,7 +668,7 @@ class CoxCCLoss(torch.nn.Module):
 
 
 class CoxPHLossSorted(torch.nn.Module):
-    """Loss for CoxPH.
+    r"""Loss for CoxPH.
     Requires the input to be sorted by descending duration time.
     See DatasetDurationSorted.
 
@@ -686,7 +686,7 @@ class CoxPHLossSorted(torch.nn.Module):
 
 
 class CoxPHLoss(torch.nn.Module):
-    """Loss for CoxPH model. If data is sorted by descending duration, see `cox_ph_loss_sorted`.
+    r"""Loss for CoxPH model. If data is sorted by descending duration, see `cox_ph_loss_sorted`.
 
     We calculate the negative log of $(\frac{h_i}{\sum_{j \in R_i} h_j})^d$,
     where h = exp(log_h) are the hazards and R is the risk set, and d is event.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,71 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pycox"
+version = "0.3.1"
+description = "Survival analysis with PyTorch"
+readme = { content-type = "text/markdown", text = """
+**pycox** is a python package for survival analysis and time-to-event prediction with [PyTorch](https://pytorch.org/).
+It is built on the [torchtuples](https://github.com/havakv/torchtuples) package for training [PyTorch](https://pytorch.org/) models.
+
+Read the documentation at: https://github.com/havakv/pycox
+
+The package contains
+
+- survival models: (Logistic-Hazard, DeepHit, DeepSurv, Cox-Time, MTLR, etc.)
+- evaluation criteria (concordance, Brier score, Binomial log-likelihood, etc.)
+- event-time datasets (SUPPORT, METABRIC, KKBox, etc)
+- simulation studies
+- illustrative examples
+""" }
+authors = [{ name = "Haavard Kvamme", email = "haavard.kvamme@gmail.com" }]
+license = "BSD-3-Clause"
+requires-python = ">=3.8"
+dependencies = [
+    "torchtuples>=0.2.0",
+    "feather-format>=0.4.0",
+    "h5py>=2.9.0",
+    "numba>=0.44",
+    "scikit-learn>=0.21.2",
+    "requests>=2.22.0",
+    "py7zr>=0.11.3",
+    "torch>=2.5.1",
+]
+keywords = ["pycox"]
+classifiers = [
+    "Development Status :: 2 - Pre-Alpha",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+]
+
+[project.urls]
+Homepage = "https://github.com/havakv/pycox"
+
+
+[tool.bumpversion]
+current_version = "0.3.0"
+commit = true
+tag = false
+
+[[tool.bumpversion.file]]
+filename = "pyproject.toml"
+search = "version = \"{current_version}\""
+replace = "version = \"{new_version}\""
+
+[[tool.bumpversion.file]]
+filename = "pycox/__init__.py"
+search = "__version__ = '{current_version}'"
+replace = "__version__ = '{new_version}'"
+
+[dependency-groups]
+dev = [
+    "lifelines>=0.27.8",
+    "pytest>=8.3.5",
+    "ruff>=0.11.12",
+    "sklearn-pandas>=2.2.0",
+]
+
+[tool.setuptools.packages.find]
+include = ["pycox*"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ requirements = [
 
 setup(
     name='pycox',
-    version='0.3.0',
+    version='0.3.1',
     description="Survival analysis with PyTorch",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
The illegal escapes lead to a lot of `SyntaxWarnings` when importing pycox. This patch fixes this issue.